### PR TITLE
Document detection improvements

### DIFF
--- a/HoloLensReceiver/Assets/Scripts/DocumentRenderer.cs
+++ b/HoloLensReceiver/Assets/Scripts/DocumentRenderer.cs
@@ -29,7 +29,7 @@ public class DocumentRenderer : MonoBehaviour
     private bool isStarted = false;
     private float timeSinceLastRender = 0.0f;
 
-    private Queue<(int width, int height, byte[] data)> documentQueue = new();
+    private Queue<(short width, short height, byte[] data)> documentQueue = new();
 
     public void Start()
     {
@@ -48,7 +48,7 @@ public class DocumentRenderer : MonoBehaviour
         xScaleUnitWidth = (1.0f * localScale.x) / currentWorldWidth;
         zScaleUnitHeight = (1.0f * localScale.z) / currentWorldHeight;
 
-        TargetRenderer.material.color = Color.white * 1.5f; // brighten by 50%
+        TargetRenderer.material.color = Color.white * 2.0f; // brighten
         TargetRenderer.enabled = false; // Initially hide the renderer
     }
 
@@ -59,7 +59,7 @@ public class DocumentRenderer : MonoBehaviour
             timeSinceLastRender += Time.deltaTime;
         }
 
-        // If the point cloud queue is not empty, render its first entry
+        // If the document queue is not empty, render its first entry
         if (documentQueue.Count > 0)
         {
             var (width, height, data) = documentQueue.Dequeue();
@@ -73,7 +73,7 @@ public class DocumentRenderer : MonoBehaviour
         }
     }
 
-    public void EnqueueDocument(int width, int height, byte[] data)
+    public void EnqueueDocument(short width, short height, byte[] data)
     {
         isStarted = true;
 
@@ -84,7 +84,7 @@ public class DocumentRenderer : MonoBehaviour
         documentQueue.Enqueue((width, height, data));
     }
 
-    public void UpdateMesh(int width, int height, byte[] data)
+    public void UpdateMesh(short width, short height, byte[] data)
     {
         if (data == null || data.Length == 0)
         {
@@ -113,7 +113,7 @@ public class DocumentRenderer : MonoBehaviour
         }
     }
 
-    private void AdjustRendererScale(int width, int height)
+    private void AdjustRendererScale(short width, short height)
     {
         float aspectRatio = (float)width / (float)height;
 

--- a/HoloLensReceiver/Assets/Scripts/HoloportReceiver.cs
+++ b/HoloLensReceiver/Assets/Scripts/HoloportReceiver.cs
@@ -192,14 +192,11 @@ public class HoloportReceiver : MonoBehaviour
         {
             try
             {
-                // Request a new frame
-                await documentClient.GetStream().WriteAsync(new byte[] { 0 });
-
                 // Read width
-                int width = await ReadIntAsync(documentClient);
+                short width = await ReadShortAsync(documentClient);
 
                 // Read height 
-                int height = await ReadIntAsync(documentClient);
+                short height = await ReadShortAsync(documentClient);
 
                 int dataSize = await ReadIntAsync(documentClient);
 

--- a/HoloLensReceiver/Assets/Scripts/PointCloudRenderer.cs
+++ b/HoloLensReceiver/Assets/Scripts/PointCloudRenderer.cs
@@ -89,11 +89,6 @@ public class PointCloudRenderer : MonoBehaviour
     {
         int pointCount = Mathf.Min(positions.Length, colorData.Length);
 
-        if (pointCount == 0)
-        {
-            return;
-        }
-
         // Find the level of precision of the point cloud from the scale that was sent
         float precision = 1.0f / scale;
 

--- a/LiveScan3D/LiveScanServer/CameraClient.cs
+++ b/LiveScan3D/LiveScanServer/CameraClient.cs
@@ -119,7 +119,7 @@ namespace LiveScanServer
         public delegate void ConfirmMasterRestartCallback(int clientIndex);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public unsafe delegate void SendDocumentCallback(int clientIndex, byte* data, float score, float width, float height);
+        public unsafe delegate void SendDocumentCallback(int clientIndex, byte* data, float score, short width, short height);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void SendDeviceSyncStateCallback(int clientIndex, int syncState);
@@ -149,8 +149,8 @@ namespace LiveScanServer
 
         public List<byte> DocumentData = new List<byte>();
         public float DocumentScore = 0.0f;
-        public float DocumentWidth = 0.0f;
-        public float DocumentHeight = 0.0f;
+        public short DocumentWidth = 0;
+        public short DocumentHeight = 0;
 
         private int clientIndex;
         private IntPtr clientHandle;
@@ -414,13 +414,13 @@ namespace LiveScanServer
 
         public unsafe void SetSendDocumentCallback(Action<int> callback)
         {
-            sendDocumentCallback = new SendDocumentCallback((int index, byte* data, float score, float width, float height) =>
+            sendDocumentCallback = new SendDocumentCallback((int index, byte* data, float score, short width, short height) =>
             {
                 DocumentData.Clear();
-                DocumentData.Capacity = (int)width * (int)height * 3; // pre-allocate for speed
+                DocumentData.Capacity = width * height * 3; // pre-allocate for speed
 
                 // Copy raw bytes into managed List<byte>
-                for (int i = 0; i < (int)width * (int)height * 3; i++)
+                for (int i = 0; i < width * height * 3; i++)
                 {
                     DocumentData.Add(data[i]);
                 }

--- a/LiveScan3D/LiveScanServer/CameraServer.cs
+++ b/LiveScan3D/LiveScanServer/CameraServer.cs
@@ -19,6 +19,7 @@ Kowalski, M.; Naruniec, J.; Daniluk, M.: "LiveScan3D: A Fast and Inexpensive
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
 
 namespace LiveScanServer
 {
@@ -123,8 +124,6 @@ namespace LiveScanServer
 
         public event ClientListChangedHandler OnClientListChanged;
         public DocumentInfo DocumentInfo = new DocumentInfo();
-
-        private const float DocumentDiffThreshold = 0.9f;
 
         private bool waitForSubordinateStart = false;
 
@@ -591,56 +590,12 @@ namespace LiveScanServer
                     return;
                 }
 
-                List<byte> newDocumentData = new List<byte>(client.DocumentData);
-                float newDocumentScore = client.DocumentScore;
-                float newDocumentWidth = client.DocumentWidth;
-                float newDocumentHeight = client.DocumentHeight;
-
-                // Check if the server has no data yet
-                if (DocumentInfo.Data == null || DocumentInfo.Data.Count == 0)
-                {
-                    DocumentInfo.Data = new List<byte>(newDocumentData);
-                    DocumentInfo.Score = newDocumentScore;
-                    DocumentInfo.Width = newDocumentWidth;
-                    DocumentInfo.Height = newDocumentHeight;
-                    DocumentInfo.IsNew = true;
-                    return;
-                }
-
-                // Compute difference
-                float diff = ComputeImageDifference(newDocumentData);
-
-                // Update if sufficiently different or higher score
-                if (diff > DocumentDiffThreshold || newDocumentScore > DocumentInfo.Score)
-                {
-                    DocumentInfo.Data = new List<byte>(newDocumentData);
-                    DocumentInfo.Score = newDocumentScore;
-                    DocumentInfo.Width = newDocumentWidth;
-                    DocumentInfo.Height = newDocumentHeight;
-                    DocumentInfo.IsNew = true;
-                }
-                else
-                {
-                    DocumentInfo.IsNew = false;
-                }
+                DocumentInfo.Data = new List<byte>(client.DocumentData);
+                DocumentInfo.Score = client.DocumentScore; ;
+                DocumentInfo.Width = client.DocumentWidth; ;
+                DocumentInfo.Height = client.DocumentHeight; ;
+                DocumentInfo.IsNew = true;
             }
-        }
-
-        private float ComputeImageDifference(List<byte> newDocumentData)
-        {
-            if (newDocumentData.Count != DocumentInfo.Data.Count || newDocumentData.Count == 0 || DocumentInfo.Data.Count == 0)
-                return 1.0f; // Completely different if sizes mismatch or empty
-
-            long diffSum = 0;
-            for (int i = 0; i < newDocumentData.Count; i++)
-            {
-                int d = newDocumentData[i] - DocumentInfo.Data[i];
-                diffSum += d * d;
-            }
-
-            // Max diff = each channel could differ by 255
-            double maxDiff = 255.0 * 255.0 * newDocumentData.Count;
-            return (float)(diffSum / maxDiff); // normalized 0..1
         }
 
         // Calls event handler to modify the client list in the main window form

--- a/LiveScan3D/LiveScanServer/DocumentTransferSocket.cs
+++ b/LiveScan3D/LiveScanServer/DocumentTransferSocket.cs
@@ -29,47 +29,35 @@ namespace LiveScanServer
     {
         public DocumentTransferSocket(TcpClient clientSocket) : base(clientSocket) { }
 
-        public void SendDocument(List<byte> data, float width, float height)
+        public void SendDocument(List<byte> data, short width, short height)
         {
-            // Receive 1 byte to check that the receiver has requested a new frame
-            byte[] requestBuffer = Receive(1);
-
-            while (requestBuffer.Length != 0)
+            try
             {
-                if (requestBuffer[0] == 0)
+                if (data == null || data.Count == 0 || width == 0 || height == 0)
                 {
-                    try
-                    {
-                        if (data == null || data.Count == 0 || width == 0 || height == 0)
-                        {
-                            return;
-                        }
-
-                        // Encode document data
-                        byte[] dataArray = EncodeToJpeg(data.ToArray(), (int)width, (int)height);
-
-                        if (dataArray == null || dataArray.Length == 0)
-                        {
-                            return;
-                        }
-
-                        // Send width and height of document first
-                        WriteInt((int)width);
-                        WriteInt((int)height);
-
-                        // Write data size
-                        WriteInt(dataArray.Length);
-
-                        // Write actual data
-                        socket.GetStream().Write(dataArray, 0, dataArray.Length);
-                    }
-                    catch (Exception)
-                    {
-                    }
+                    return;
                 }
 
-                // Receive a new request byte to make sure the receiver is ready to receive
-                requestBuffer = Receive(1);
+                // Encode document data
+                byte[] dataArray = EncodeToJpeg(data.ToArray(), width, height);
+
+                if (dataArray == null || dataArray.Length == 0)
+                {
+                    return;
+                }
+
+                // Send width and height of document first
+                WriteShort(width);
+                WriteShort(height);
+
+                // Write data size
+                WriteInt(dataArray.Length);
+
+                // Write actual data
+                socket.GetStream().Write(dataArray, 0, dataArray.Length);
+            }
+            catch (Exception)
+            {
             }
         }
 

--- a/LiveScan3D/LiveScanServer/TransferServer.cs
+++ b/LiveScan3D/LiveScanServer/TransferServer.cs
@@ -282,20 +282,21 @@ namespace LiveScanServer
         {
             while (isDocumentServerRunning && !token.IsCancellationRequested)
             {
-                // Send latest document to all connected clients
-                for (int i = 0; i < documentClients.Count; i++)
+                if (DocumentInfo.IsNew)
                 {
-                    // Send a point cloud frame
                     lock (DocumentInfo)
                     {
-                        if (DocumentInfo.IsNew)
+                        // Send latest document to all connected clients
+                        for (int i = 0; i < documentClients.Count; i++)
                         {
                             documentClients[i].SendDocument(DocumentInfo.Data, DocumentInfo.Width, DocumentInfo.Height);
                         }
                     }
+
+                    DocumentInfo.IsNew = false;
                 }
 
-                await Task.Delay(1000);
+                await Task.Delay(100);
             }
         }
     }

--- a/LiveScan3D/LiveScanServer/TransferSocketBase.cs
+++ b/LiveScan3D/LiveScanServer/TransferSocketBase.cs
@@ -62,6 +62,11 @@ namespace LiveScanServer
             return buffer;
         }
 
+        protected void WriteShort(short val)
+        {
+            socket.GetStream().Write(BitConverter.GetBytes(val), 0, 2);
+        }
+
         protected void WriteInt(int val)
         {
             socket.GetStream().Write(BitConverter.GetBytes(val), 0, 4);

--- a/LiveScan3D/LiveScanServer/Utils.cs
+++ b/LiveScan3D/LiveScanServer/Utils.cs
@@ -197,8 +197,8 @@ namespace LiveScanServer
     {
         public List<byte> Data { get; set; } = new List<byte>();
         public float Score { get; set; }
-        public float Width { get; set; }
-        public float Height { get; set; }
+        public short Width { get; set; }
+        public short Height { get; set; }
         public bool IsNew { get; set; }
     }
 

--- a/LiveScan3D/include/LiveScanClient/documentDetector.h
+++ b/LiveScan3D/include/LiveScanClient/documentDetector.h
@@ -25,7 +25,7 @@ public:
     // Type alias for the detection callback
     using DetectionCallback = std::function<void(const DetectionResult&)>;
 
-    DocumentDetector(int deviceIdx);
+    DocumentDetector();
     ~DocumentDetector();
 
     void DocumentDetector::SubmitFrame(std::shared_ptr<ob::ColorFrame> color, cv::Mat depth);
@@ -34,8 +34,8 @@ public:
         const std::shared_ptr<ob::ColorFrame>& colorFrame,
         cv::Mat depthFrame,
         cv::Mat& documentData,
-        float& documentPictureWidth,
-        float& documentPicutreHeight,
+        short& documentPictureWidth,
+        short& documentPicutreHeight,
         float& documentScore
     );
 
@@ -43,9 +43,6 @@ public:
     void SetLogger(std::function<void(const std::string&)> loggerFunc);
 
 private:
-    int counter = 0;
-    int deviceIndex = -1;
-
     std::mutex frameMutex;
     std::condition_variable frameCond;
 

--- a/LiveScan3D/include/LiveScanClient/iCaptureManager.h
+++ b/LiveScan3D/include/LiveScanClient/iCaptureManager.h
@@ -39,8 +39,9 @@ public:
 
 	cv::Mat lastDocumentData;
 	float lastDocumentScore;
-	float lastDocumentWidth;
-	float lastDocumentHeight;
+	short lastDocumentWidth;
+	short lastDocumentHeight;
+	bool hasNewDocument;
 
 	std::string serialNumber;
 

--- a/LiveScan3D/include/LiveScanClient/liveScanClient.h
+++ b/LiveScan3D/include/LiveScanClient/liveScanClient.h
@@ -70,7 +70,8 @@ private:
     const float YRangeCenter = 0.0f;
     const float ZRangeCenter = HalfRange;
 
-    const float DocumentDiffThreshold = 0.99;
+    const float DocumentDiffThreshold = 0.50;
+    const int DocumentSendTimeout = 30000; // In milliseconds
 
     int clientIndex = -1;
     bool isClientThreadRunning;
@@ -108,8 +109,9 @@ private:
 
     cv::Mat lastDocumentData;
     float lastDocumentScore;
-    float lastDocumentWidth;
-    float lastDocumentHeight;
+    short lastDocumentWidth;
+    short lastDocumentHeight;
+    std::chrono::milliseconds lastDocumentSendTime;
 
     Point3f* cameraSpaceCoordinates;
 

--- a/LiveScan3D/include/LiveScanClient/liveScanClientWrapper.h
+++ b/LiveScan3D/include/LiveScanClient/liveScanClientWrapper.h
@@ -31,7 +31,7 @@ typedef void(*SendLatestFrameCallback)(int clientIndex, const Point3s* vertices,
 typedef void(*SendRecordedFrameCallback)(int clientIndex, const Point3s* vertices, const RGB* colors, int count, bool noMoreFrames);
 typedef void(*ConfirmSyncStateCallback)(int clientIndex, int tempSyncState);
 typedef void(*ConfirmMasterRestartCallback)(int clientIndex);
-typedef void(*SendDocumentCallback)(int clientIndex, const unsigned char* data, float score, float width, float height);
+typedef void(*SendDocumentCallback)(int clientIndex, const unsigned char* data, float score, short width, short height);
 
 struct LiveScanClientWrapper {
 	std::unique_ptr<LiveScanClient> client;

--- a/LiveScan3D/include/LiveScanClient/orbbecCaptureManager.h
+++ b/LiveScan3D/include/LiveScanClient/orbbecCaptureManager.h
@@ -47,12 +47,11 @@ public:
 private:
     const int SyncDelayUs = 160;
     const int DocumentServerSendDelayMs = 1000;
-    const int CaptureTimeoutMs = 1000;
+    const int CaptureTimeoutMs = 500;
 
     int deviceIndex = 0;
     int deviceIDForRestart = -1;
     int restartAttempts = 0;
-    int counter = 0;
 
     std::shared_ptr<ob::Device> device;
     std::shared_ptr<ob::Pipeline> pipeline;

--- a/LiveScan3D/include/LiveScanClient/utils.h
+++ b/LiveScan3D/include/LiveScanClient/utils.h
@@ -123,8 +123,8 @@ typedef struct RGB
 
 typedef struct DetectionResult {
 	cv::Mat data;
-	float width;
-	float height;
+	short width;
+	short height;
 	float score;
 };
 

--- a/LiveScan3D/src/LiveScanClient/iCaptureManager.cpp
+++ b/LiveScan3D/src/LiveScanClient/iCaptureManager.cpp
@@ -28,6 +28,8 @@ ICaptureManager::ICaptureManager()
 
 	depthData = NULL;
 	colorData = NULL;
+
+	hasNewDocument = false;
 }
 
 ICaptureManager::~ICaptureManager()

--- a/LiveScan3D/src/LiveScanClient/orbbecCaptureManager.cpp
+++ b/LiveScan3D/src/LiveScanClient/orbbecCaptureManager.cpp
@@ -28,7 +28,7 @@ Kowalski, M.; Naruniec, J.; Daniluk, M.: "LiveScan3D: A Fast and Inexpensive
 
 OrbbecCaptureManager::OrbbecCaptureManager(int deviceIndex) : deviceIndex(deviceIndex), lastFrameTime(0)
 {
-    documentDetector = std::make_unique<DocumentDetector>(deviceIndex);
+    documentDetector = std::make_unique<DocumentDetector>();
 
     documentDetector->SetDetectionCallback([=](const DetectionResult& result) {
         // Save the new detection result
@@ -36,6 +36,7 @@ OrbbecCaptureManager::OrbbecCaptureManager(int deviceIndex) : deviceIndex(device
         lastDocumentWidth = result.width;
         lastDocumentData = result.data;
         lastDocumentScore = result.score;
+        hasNewDocument = true;
     });
 }
 


### PR DESCRIPTION
This introduces some improvements of the document detection process, namely:
- Fixed the logic to only send documents when they are different enough or less blurry than the previous one
- Added a timeout mechanism to send any detection after a timeout, even if they are not different enough or less blurry
- Represented width and height as shorts rather than floats to optimize the size of the data sent through the network
- Fixed small issue with the point cloud rendering where points were still rendered after the object was taken out of the physical box